### PR TITLE
fix: remove dollar prefix and folder spelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules/
 *.zshrc
 hs_err_pid*.log
 /.metadata/
+.env

--- a/examples/petstore/README.md
+++ b/examples/petstore/README.md
@@ -7,15 +7,15 @@ Both HTTP AsyncAPI 3.x spec & Kafka AsyncAPI 3.x spec are generated automaticall
 #### Install `zillabase`
 
 ```bash
-$ brew tap aklivity/tap
+brew tap aklivity/tap
 
-$ brew install zillabase
+brew install zillabase
 ```
 
 #### Start `zillabase` stack:
 
 ```bash
-$ zillabase start
+zillabase start
 ```
 
 Output:

--- a/examples/streampay/README.md
+++ b/examples/streampay/README.md
@@ -8,15 +8,15 @@ Both HTTP AsyncAPI 3.x spec & Kafka AsyncAPI 3.x spec are generated automaticall
 #### Install `zillabase`
 
 ```bash
-$ brew tap aklivity/tap
+brew tap aklivity/tap
 
-$ brew install zillabase
+brew install zillabase
 ```
 
 #### Start `zillabase` stack:
 
 ```bash
-$ zillabase start
+zillabase start
 ```
 
 Output:
@@ -84,10 +84,10 @@ The Zillabase Streampay is exposes common entity CRUD endpoints with the entity 
 | HTTP     | GET    | /streampay_payment_requests-stream | dev.streampay_payment_requests | Stream new available payment request.        |
 | HTTP     | GET    | /streampay_activities-stream       | dev.streampay_activities       | Stream all the activities.                   |
 
-
 ## Setup StreamPay UI
 
 ### Install the dependencies
+
 ```bash
 yarn
 # or
@@ -95,6 +95,7 @@ npm install
 ```
 
 ### Start the app in development mode (hot-code reloading, error reporting, etc.)
+
 ```bash
 quasar dev
 ```

--- a/examples/udf.java/README.md
+++ b/examples/udf.java/README.md
@@ -5,8 +5,8 @@ This example demonstrates how to register external User Defined Functions (UDFs)
 #### Build external User Defined Functions (UDFs)
 
 ```bash
-$ cd zillabase/functions/java/risingwave-java-udf-template/
-$ ./mvnw clean install
+cd zillabase/functions/java/risingwave-java-udf-template/
+./mvnw clean install
 ```
 
 Output:
@@ -20,21 +20,21 @@ Output:
 #### Install `zillabase`
 
 ```bash
-$ brew tap aklivity/tap
+brew tap aklivity/tap
 
-$ brew install zillabase
+brew install zillabase
 ```
 
 Note: To use a local build, you can define an alias as follows:
 
 ```bash
-$ alias zillabase="java -jar `pwd`/cli/target/cli-develop-SNAPSHOT.jar"
+alias zillabase="java -jar `pwd`/cli/target/cli-develop-SNAPSHOT.jar"
 ```
 
 #### Start `zillabase` stack:
 
 ```bash
-$ zillabase start
+zillabase start
 ```
 
 Output:
@@ -52,7 +52,7 @@ latest: Pulling from aklivity/zillabase/udf-server
 #### Connect to psql endpoint expose through Admin service
 
 ```bash
-$ psql -U root -d dev -h localhost -p 4567
+psql -U root -d dev -h localhost -p 4567
 ```
 
 #### Validate defined functions:

--- a/examples/udf.java/README.md
+++ b/examples/udf.java/README.md
@@ -25,12 +25,6 @@ brew tap aklivity/tap
 brew install zillabase
 ```
 
-Note: To use a local build, you can define an alias as follows:
-
-```bash
-alias zillabase="java -jar `pwd`/cli/target/cli-develop-SNAPSHOT.jar"
-```
-
 #### Start `zillabase` stack:
 
 ```bash

--- a/examples/udf.python/README.md
+++ b/examples/udf.python/README.md
@@ -5,15 +5,15 @@ This example demonstrates how to register external User Defined Functions (UDFs)
 #### Install `zillabase`
 
 ```bash
-$ brew tap aklivity/tap
+brew tap aklivity/tap
 
-$ brew install zillabase
+brew install zillabase
 ```
 
 #### Start `zillabase` stack:
 
 ```bash
-$ zillabase start
+zillabase start
 ```
 
 Output:
@@ -31,7 +31,7 @@ latest: Pulling from aklivity/zillabase/udf-server
 #### Connect to psql endpoint expose through Admin service
 
 ```bash
-$ psql -U root -d dev -h localhost -p 4567
+psql -U root -d dev -h localhost -p 4567
 ```
 
 #### Validate defined functions:


### PR DESCRIPTION
## Description

simple fix for readability.  Using `bash` as the language for code blocks is enough and allows easier copy of commands
