### PR TITLE
Support sql migrations

### DIFF
--- a/cli/src/main/java/io/aklivity/zillabase/cli/config/ZillabaseRisingWaveConfig.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/config/ZillabaseRisingWaveConfig.java
@@ -17,11 +17,9 @@ package io.aklivity.zillabase.cli.config;
 public final class ZillabaseRisingWaveConfig
 {
     private static final String DEFAULT_RISINGWAVE_TAG = "v1.10.2";
-    private static final int DEFAULT_RISINGWAVE_PORT = 4567;
     private static final String DEFAULT_RISINGWAVE_DB = "dev";
 
-    public static final String DEFAULT_RISINGWAVE_INTERNAL_URL = "risingwave.zillabase.dev:4566";
-    public static final String DEFAULT_RISINGWAVE_URL = "localhost:%d".formatted(DEFAULT_RISINGWAVE_PORT);
+    public static final String DEFAULT_RISINGWAVE_URL = "risingwave.zillabase.dev:4566";
 
     public String tag = DEFAULT_RISINGWAVE_TAG;
     public String url = DEFAULT_RISINGWAVE_URL;

--- a/cli/src/main/java/io/aklivity/zillabase/cli/internal/ZillabaseCli.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/internal/ZillabaseCli.java
@@ -26,6 +26,8 @@ import io.aklivity.zillabase.cli.internal.commands.config.add.ZillabaseConfigAdd
 import io.aklivity.zillabase.cli.internal.commands.config.list.ZillabaseConfigListCommand;
 import io.aklivity.zillabase.cli.internal.commands.config.remove.ZillabaseConfigRemoveCommand;
 import io.aklivity.zillabase.cli.internal.commands.init.ZillabaseInitCommand;
+import io.aklivity.zillabase.cli.internal.commands.migration.add.ZillabaseMigrationAddCommand;
+import io.aklivity.zillabase.cli.internal.commands.migration.list.ZillabaseMigrationListCommand;
 import io.aklivity.zillabase.cli.internal.commands.sso.add.ZillabaseSsoAddCommand;
 import io.aklivity.zillabase.cli.internal.commands.sso.list.ZillabaseSsoListCommand;
 import io.aklivity.zillabase.cli.internal.commands.sso.remove.ZillabaseSsoRemoveCommand;
@@ -67,6 +69,16 @@ import io.aklivity.zillabase.cli.internal.commands.stop.ZillabaseStopCommand;
                 ZillabaseSsoAddCommand.class,
                 ZillabaseSsoListCommand.class,
                 ZillabaseSsoRemoveCommand.class
+            }),
+        @Group(
+            name = "migration",
+            description = "Manage migrations",
+            defaultCommand = Help.class,
+            commands =
+            {
+                Help.class,
+                ZillabaseMigrationAddCommand.class,
+                ZillabaseMigrationListCommand.class
             })
     },
     commands =

--- a/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/ZillabaseCommand.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/ZillabaseCommand.java
@@ -14,6 +14,10 @@
  */
 package io.aklivity.zillabase.cli.internal.commands;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import javax.inject.Inject;
 
 import com.github.rvesse.airline.HelpOption;
@@ -23,20 +27,54 @@ public abstract class ZillabaseCommand implements Runnable
 {
     public static final String VERSION = ZillabaseCommand.class.getPackage().getImplementationVersion();
 
+    public static final Path ZILLABASE_PATH = Paths.get("zillabase");
+
     @Inject
     public HelpOption<ZillabaseCommand> helpOption;
 
     @Option(name = { "--debug" })
     public Boolean debug = false;
 
+    private final boolean requiresProject;
+
+    protected ZillabaseCommand()
+    {
+        this(true);
+    }
+
+    protected ZillabaseCommand(
+        boolean requiresProject)
+    {
+        this.requiresProject = requiresProject;
+    }
+
     @Override
     public void run()
     {
-        if (!helpOption.showHelpIfRequested())
+        if (!helpOption.showHelpIfRequested() &&
+            checkProjectIfRequired())
         {
             invoke();
         }
     }
 
     protected abstract void invoke();
+
+
+    protected boolean checkProjectIfRequired()
+    {
+        boolean checkOkay = true;
+
+        if (requiresProject)
+        {
+            boolean exists = Files.exists(ZILLABASE_PATH);
+            if (!exists)
+            {
+                System.out.println("zillabase project not found, needs zillabase init ?");
+            }
+            checkOkay = exists;
+        }
+
+        return checkOkay;
+    }
 }

--- a/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/init/ZillabaseInitCommand.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/init/ZillabaseInitCommand.java
@@ -28,6 +28,11 @@ import io.aklivity.zillabase.cli.internal.commands.ZillabaseCommand;
     description = "Initialize a local project")
 public final class ZillabaseInitCommand extends ZillabaseCommand
 {
+    public ZillabaseInitCommand()
+    {
+        super(false);
+    }
+
     @Override
     protected void invoke()
     {

--- a/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/migration/ZillabaseMigrationCommand.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/migration/ZillabaseMigrationCommand.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zillabase.cli.internal.commands.migration;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.aklivity.zillabase.cli.internal.commands.ZillabaseCommand;
+import io.aklivity.zillabase.cli.internal.migrations.ZillabaseMigrationsHelper;
+
+public abstract class ZillabaseMigrationCommand extends ZillabaseCommand
+{
+    protected static final Path MIGRATIONS_PATH = ZillabaseMigrationsHelper.MIGRATIONS_PATH;
+
+    protected static final Pattern MIGRATION_FILE_PATTERN = ZillabaseMigrationsHelper.MIGRATION_FILE_PATTERN;
+    protected static final String MIGRATION_FILE_FORMAT = ZillabaseMigrationsHelper.MIGRATION_FILE_FORMAT;
+
+    protected final Matcher matcher;
+
+    private final ZillabaseMigrationsHelper helper;
+
+    protected ZillabaseMigrationCommand()
+    {
+        this.helper = new ZillabaseMigrationsHelper();
+        this.matcher = helper.matcher;
+    }
+
+    protected final Stream<String> listMigrations() throws IOException
+    {
+        return helper.list()
+            .map(p -> p.getFileName().toString());
+    }
+}

--- a/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/migration/add/ZillabaseMigrationAddCommand.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/migration/add/ZillabaseMigrationAddCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zillabase.cli.internal.commands.migration.add;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.restrictions.Required;
+
+import io.aklivity.zillabase.cli.internal.commands.migration.ZillabaseMigrationCommand;
+
+@Command(
+    name = "add",
+    description = "Creates a new migration file locally")
+public final class ZillabaseMigrationAddCommand extends ZillabaseMigrationCommand
+{
+    @Arguments(title = { "name" })
+    @Required
+    public List<String> args;
+
+    @Override
+    protected void invoke()
+    {
+        try
+        {
+            String name = args.get(0);
+
+            Optional<String> latest = listMigrations().reduce((n1, n2) -> n2);
+
+            int next = latest.isPresent() && matcher.reset(latest.get()).matches()
+                ? Integer.parseInt(matcher.group("number")) + 1
+                : 0;
+
+            String filename = MIGRATION_FILE_FORMAT.formatted(next, name);
+            Path newMigration = MIGRATIONS_PATH.resolve(filename);
+
+            Files.createDirectories(MIGRATIONS_PATH);
+            Files.createFile(newMigration);
+
+            System.out.printf("Created migration %s\n", filename);
+        }
+        catch (IOException ex)
+        {
+            ex.printStackTrace(System.err);
+        }
+    }
+}

--- a/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/migration/list/ZillabaseMigrationListCommand.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/internal/commands/migration/list/ZillabaseMigrationListCommand.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zillabase.cli.internal.commands.migration.list;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import com.github.rvesse.airline.annotations.Command;
+
+import io.aklivity.zillabase.cli.internal.commands.migration.ZillabaseMigrationCommand;
+
+@Command(
+    name = "list",
+    description = "Lists local migrations")
+public final class ZillabaseMigrationListCommand extends ZillabaseMigrationCommand
+{
+    @Override
+    protected void invoke()
+    {
+        try
+        {
+            Stream<String> migrations = listMigrations();
+
+            migrations.forEach(System.out::println);
+        }
+        catch (IOException ex)
+        {
+            ex.printStackTrace(System.err);
+        }
+    }
+}

--- a/cli/src/main/java/io/aklivity/zillabase/cli/internal/migrations/ZillabaseMigrationsHelper.java
+++ b/cli/src/main/java/io/aklivity/zillabase/cli/internal/migrations/ZillabaseMigrationsHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zillabase.cli.internal.migrations;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.aklivity.zillabase.cli.internal.commands.ZillabaseCommand;
+
+public final class ZillabaseMigrationsHelper
+{
+    public static final Path MIGRATIONS_PATH = ZillabaseCommand.ZILLABASE_PATH.resolve("migrations");
+
+    public static final Pattern MIGRATION_FILE_PATTERN = Pattern.compile("(?<number>\\d{6})__.+\\.sql");
+    public static final String MIGRATION_FILE_FORMAT = "%06d__%s.sql";
+
+    public final Matcher matcher = MIGRATION_FILE_PATTERN.matcher("");
+
+    public Stream<Path> list()
+    {
+        Stream<Path> migrations;
+
+        try
+        {
+            migrations = Files.list(MIGRATIONS_PATH)
+                .sorted()
+                .filter(Files::isRegularFile)
+                .filter(n -> matcher.reset(n.getFileName().toString()).matches());
+        }
+        catch (IOException ex)
+        {
+            migrations = Stream.empty();
+        }
+
+        return migrations;
+    }
+}

--- a/examples/petstore/zillabase/migrations/000000__create_tables.sql
+++ b/examples/petstore/zillabase/migrations/000000__create_tables.sql
@@ -1,0 +1,19 @@
+-- create_tables
+
+CREATE TABLE petstore_pets(
+  id VARCHAR,
+  breed VARCHAR,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE petstore_customers(
+  name VARCHAR,
+  status VARCHAR,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE petstore_verified_customers(
+  id VARCHAR,
+  points VARCHAR,
+  PRIMARY KEY (id)
+);

--- a/examples/petstore/zillabase/seed.sql
+++ b/examples/petstore/zillabase/seed.sql
@@ -1,23 +1,5 @@
 -- seed
 
-CREATE TABLE petstore_pets(
-  id VARCHAR,
-  breed VARCHAR,
-  PRIMARY KEY (id)
-);
-
-CREATE TABLE petstore_customers(
-  name VARCHAR,
-  status VARCHAR,
-  PRIMARY KEY (name)
-);
-
-CREATE TABLE petstore_verified_customers(
-  id VARCHAR,
-  points VARCHAR,
-  PRIMARY KEY (id)
-);
-
 INSERT INTO petstore_pets (id, breed) VALUES ('123', 'German Shepherd');
 INSERT INTO petstore_pets (id, breed) VALUES ('234', 'Beagle');
 


### PR DESCRIPTION
## Description

Adds commands for the following:
  - `zillabase migration add <name>`
  - `zillabase migration list`

Processes all migrations in order before seed.sql on `zillabase start`.

Fixes #101 
